### PR TITLE
Add EPUB newsletter builder

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dotenv
 pydantic
 requests
 langchain-google-genai
+ebooklib

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -10,6 +10,7 @@ from src.models.data_models import RawArticle, ProcessedArticle
 from src.agents.data_fetchers.newsapi_fetcher import NewsAPIFetcher 
 from src.agents.llm_processors.summarizer_agent import SummarizerAgent
 from src.agents.llm_processors.categorizer_agent import CategorizerAgent # Categorizer importiert
+from src.utils.epub_builder import build_newsletter_epub
 
 logger = logging.getLogger(__name__)
 
@@ -146,6 +147,14 @@ class NewsletterOrchestrator:
         except Exception as e:
             logger.error(f"Fehler beim Schreiben des Platzhalter-Newsletters: {e}", exc_info=True)
             newsletter_output_path = "Fehler beim Schreiben"
+        # Erstelle zusätzlich eine EPUB-Version des Newsletters
+        epub_path = "tmp/newsletter.epub"
+        try:
+            build_newsletter_epub(final_items_for_newsletter, epub_path)
+            newsletter_output_path = epub_path
+            logger.info(f"EPUB-Newsletter erstellt unter: {epub_path}")
+        except Exception as e:
+            logger.error(f"Fehler beim Erstellen des EPUB-Newsletters: {e}", exc_info=True)
 
         # --- Schritt 5: Newsletter verteilen (Platzhalter) ---
         # ... (bleibt gleich) ...

--- a/src/utils/epub_builder.py
+++ b/src/utils/epub_builder.py
@@ -1,0 +1,47 @@
+from typing import List
+from ebooklib import epub
+from src.models.data_models import ProcessedArticle
+import logging
+
+logger = logging.getLogger(__name__)
+
+def build_newsletter_epub(articles: List[ProcessedArticle], output_path: str) -> str:
+    """Create an EPUB newsletter from processed articles.
+
+    Args:
+        articles: List of processed articles with title, summary, etc.
+        output_path: File path where the EPUB will be written.
+
+    Returns:
+        The path to the written EPUB file.
+    """
+    book = epub.EpubBook()
+    book.set_identifier("newsletter")
+    book.set_title("Newsletter")
+    book.set_language("de")
+    book.add_author("Automatisierter Newsletter")
+
+    chapters = []
+    for idx, art in enumerate(articles, start=1):
+        title = art.title or f"Artikel {idx}"
+        html_content = (
+            f"<h1>{title}</h1>"
+            f"<p><strong>Quelle:</strong> {art.source_name or ''}</p>"
+            f"<p><strong>Kategorie:</strong> {art.category or ''}</p>"
+            f"<p>{art.summary}</p>"
+        )
+        if art.url:
+            html_content += f"<p><a href='{art.url}'>Originalartikel</a></p>"
+        chapter = epub.EpubHtml(title=title, file_name=f"chap_{idx}.xhtml", lang="de")
+        chapter.content = html_content
+        book.add_item(chapter)
+        chapters.append(chapter)
+
+    book.toc = tuple(chapters)
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = ["nav"] + chapters
+
+    epub.write_epub(output_path, book)
+    logger.info(f"EPUB Newsletter erstellt: {output_path}")
+    return output_path


### PR DESCRIPTION
## Summary
- build newsletter EPUBs via new `build_newsletter_epub` helper
- integrate EPUB creation into orchestrator
- install `ebooklib` dependency

## Testing
- `python test_models.py`


------
https://chatgpt.com/codex/tasks/task_e_68418cd652048320af7da266db6006cf