### PR TITLE
Add image URL support

### DIFF
--- a/src/agents/data_fetchers/newsapi_fetcher.py
+++ b/src/agents/data_fetchers/newsapi_fetcher.py
@@ -134,7 +134,8 @@ class NewsAPIFetcher(BaseDataFetcher):
                         content_snippet=article_item.get("content"), # NewsAPI liefert oft nur einen Snippet hier
                         published_at=article_item.get("publishedAt"), # String wird von Pydantic geparsed
                         source_name=article_item.get("source", {}).get("name", self.source_name),
-                        source_id=article_item.get("source", {}).get("id")
+                        source_id=article_item.get("source", {}).get("id"),
+                        image_url=article_item.get("urlToImage")
                     )
                     fetched_articles.append(raw_article)
                 except Exception as e_article_parse: # Fängt Pydantic ValidationErrors oder andere Fehler ab

--- a/src/agents/llm_processors/summarizer_agent.py
+++ b/src/agents/llm_processors/summarizer_agent.py
@@ -108,7 +108,8 @@ ZUSAMMENFASSUNG:""")
             # Kategorie und Relevanz werden von anderen Agenten hinzugefügt
             source_name=article.source_name,
             published_at=article.published_at,
-            llm_processing_details={"summarizer_model": self.model_name}
+            llm_processing_details={"summarizer_model": self.model_name},
+            image_url=article.image_url
         )
 
     def process_batch(self, articles: List[RawArticle]) -> List[ProcessedArticle]:

--- a/src/models/data_models.py
+++ b/src/models/data_models.py
@@ -48,6 +48,7 @@ class RawArticle(BaseModel):
     published_at: Optional[datetime] = Field(default=None)
     source_name: Optional[str] = Field(default=None)
     source_id: Optional[str] = Field(default=None) # z.B. von NewsAPI
+    image_url: Optional[HttpUrl] = Field(default=None)
 
     _ensure_published_at_tz_aware = field_validator('published_at', mode='before')(ensure_timezone_aware)
 
@@ -62,6 +63,7 @@ class ProcessedArticle(BaseModel):
     published_at: Optional[datetime] = Field(default=None)
     llm_processing_details: Dict[str, Any] = Field(default_factory=dict)
     article_text: Optional[str] = Field(default=None)
+    image_url: Optional[HttpUrl] = Field(default=None)
 
     _ensure_published_at_tz_aware = field_validator('published_at', mode='before')(ensure_timezone_aware)
 


### PR DESCRIPTION
## Summary
- add `image_url` field to article models
- fill `image_url` from NewsAPI data
- keep image info through summarization step

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841a5ac47ac83208ed96fe9bfebd466