### PR TITLE
Add weather forecast via OpenWeatherMap

### DIFF
--- a/src/agents/data_fetchers/__init__.py
+++ b/src/agents/data_fetchers/__init__.py
@@ -1,0 +1,4 @@
+from .newsapi_fetcher import NewsAPIFetcher
+from .openweathermap_fetcher import OpenWeatherMapFetcher
+
+__all__ = ["NewsAPIFetcher", "OpenWeatherMapFetcher"]

--- a/src/agents/data_fetchers/openweathermap_fetcher.py
+++ b/src/agents/data_fetchers/openweathermap_fetcher.py
@@ -1,0 +1,80 @@
+# newsletter_project/src/agents/data_fetchers/openweathermap_fetcher.py
+"""Fetcher for weather data using OpenWeatherMap API."""
+
+import requests
+import logging
+from typing import List
+
+from src.agents.data_fetchers.base_fetcher import BaseDataFetcher
+from src.models.data_models import WeatherInfo
+from src.utils.config_loader import get_api_key
+
+logger = logging.getLogger(__name__)
+
+class OpenWeatherMapFetcher(BaseDataFetcher):
+    """Fetches 5 day weather forecast for a given city."""
+
+    BASE_URL = "https://api.openweathermap.org/data/2.5/forecast"
+
+    def __init__(self, city: str = "Zurich", api_key_name: str = "OPENWEATHER_API_KEY", units: str = "metric"):
+        source_name = f"OpenWeatherMap {city}"
+        super().__init__(source_name=source_name)
+        self.city = city
+        self.api_key = get_api_key(api_key_name)
+        self.units = units
+
+    def fetch_data(self) -> List[WeatherInfo]:
+        params = {
+            "q": self.city,
+            "appid": self.api_key,
+            "units": self.units,
+        }
+        try:
+            logger.info(f"Fetching weather for {self.city} from OpenWeatherMap")
+            resp = requests.get(self.BASE_URL, params=params, timeout=20)
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as e:
+            logger.error(f"Error fetching weather data: {e}")
+            return []
+
+        forecast_list = data.get("list", [])
+        if not forecast_list:
+            logger.warning("No forecast data returned from OpenWeatherMap")
+            return []
+
+        daily_data = {}
+        for entry in forecast_list:
+            ts = entry.get("dt_txt")
+            if not ts:
+                continue
+            day = ts.split(" ")[0]
+            if day not in daily_data:
+                daily_data[day] = entry
+            if len(daily_data) == 5:
+                break
+
+        weather_infos: List[WeatherInfo] = []
+        for day, entry in daily_data.items():
+            main = entry.get("main", {})
+            weather = entry.get("weather", [{}])[0]
+            wind = entry.get("wind", {})
+            temp = main.get("temp")
+            condition = weather.get("description", "")
+            humidity = main.get("humidity")
+            wind_speed = wind.get("speed")
+            icon = weather.get("icon")
+            icon_url = f"https://openweathermap.org/img/wn/{icon}@2x.png" if icon else None
+            snippet = f"{day}: {temp}°C, {condition}"
+            info = WeatherInfo(
+                location=self.city,
+                temperature_celsius=temp,
+                condition=condition,
+                humidity_percent=humidity,
+                wind_speed_kmh=wind_speed,
+                icon_url=icon_url,
+                forecast_snippet=snippet,
+            )
+            weather_infos.append(info)
+        logger.info(f"Fetched {len(weather_infos)} weather entries from OpenWeatherMap")
+        return weather_infos

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -6,8 +6,9 @@ from datetime import datetime, timezone
 from typing import List, Optional, Any, Dict 
 
 from src.utils.config_loader import load_env, get_env_variable
-from src.models.data_models import RawArticle, ProcessedArticle
+from src.models.data_models import RawArticle, ProcessedArticle, WeatherInfo
 from src.agents.data_fetchers.newsapi_fetcher import NewsAPIFetcher
+from src.agents.data_fetchers.openweathermap_fetcher import OpenWeatherMapFetcher
 from src.agents.llm_processors.summarizer_agent import SummarizerAgent
 from src.agents.llm_processors.categorizer_agent import CategorizerAgent
 from src.agents.llm_processors.article_writer_agent import ArticleWriterAgent
@@ -28,9 +29,17 @@ class NewsletterOrchestrator:
 
         self.news_api_fetchers: List[NewsAPIFetcher] = [
             NewsAPIFetcher(query="Künstliche Intelligenz OR Technologie", language="de", endpoint="everything", days_ago=1, page_size=3, source_name_override="KI & Tech News (DE)"), # page_size reduziert für Tests
-            NewsAPIFetcher(country="ch", category="technology", endpoint="top-headlines", page_size=2, source_name_override="Schweiz Tech-Schlagzeilen"), 
+            NewsAPIFetcher(country="ch", category="technology", endpoint="top-headlines", page_size=2, source_name_override="Schweiz Tech-Schlagzeilen"),
             NewsAPIFetcher(query="global innovation OR science breakthrough", language="en", endpoint="everything", days_ago=1, page_size=3, source_name_override="Internationale Innovation (EN)")
         ]
+
+        # Weather fetcher for Zurich
+        try:
+            self.weather_fetcher = OpenWeatherMapFetcher(city="Zurich")
+            logger.info("OpenWeatherMapFetcher erfolgreich initialisiert.")
+        except Exception as e:
+            logger.error(f"Fehler bei der Initialisierung des OpenWeatherMapFetcher: {e}", exc_info=True)
+            self.weather_fetcher = None
         
         try:
             self.summarizer = SummarizerAgent() 
@@ -93,6 +102,17 @@ class NewsletterOrchestrator:
                 logger.error(f"Fehler beim Abrufen von Daten durch Fetcher '{fetcher.source_name}': {e}", exc_info=True)
         logger.info(f"Insgesamt {len(all_fetched_articles)} Rohartikel von allen Quellen gesammelt.")
         return all_fetched_articles
+
+    def _fetch_weather(self) -> List[WeatherInfo]:
+        """Fetch weather forecast information."""
+        if not self.weather_fetcher:
+            logger.warning("Weather fetcher not available. Skipping weather data fetch.")
+            return []
+        try:
+            return self.weather_fetcher.fetch_data()
+        except Exception as e:
+            logger.error(f"Fehler beim Abrufen der Wetterdaten: {e}", exc_info=True)
+            return []
 
     def _filter_blacklisted_sources(self, articles: List[RawArticle]) -> List[RawArticle]:
         """Entfernt Artikel von Quellen, die in der Blacklist stehen."""
@@ -198,9 +218,10 @@ class NewsletterOrchestrator:
         logger.info(f"{len(processed_articles)} Artikel nach LLM-Verarbeitung vorhanden.")
         for i, article in enumerate(processed_articles[:1]): # Ersten verarbeiteten Artikel loggen
             logger.debug(f"  Verarbeiteter Artikel {i+1}: '{article.title}' - Zusammenfassung (erste 50 Zeichen): '{article.summary[:50]}...' - Kategorie: {article.category}")
-        
+
         # --- Schritt 3: Daten evaluieren (Platzhalter) ---
-        final_items_for_newsletter = processed_articles 
+        final_items_for_newsletter = processed_articles
+        weather_infos = self._fetch_weather()
 
         # --- Schritt 4: Newsletter komponieren (Platzhalter) ---
         output_format = get_env_variable("NEWSLETTER_OUTPUT_FORMAT", "txt").lower()
@@ -215,6 +236,7 @@ class NewsletterOrchestrator:
                     newsletter_output_path,
                     articles_per_page=articles_per_page,
                     use_a4_css=use_a4_css,
+                    weather_infos=weather_infos,
                 )
                 logger.info(f"EPUB erstellt unter: {newsletter_output_path}")
 

--- a/src/utils/epub_utils.py
+++ b/src/utils/epub_utils.py
@@ -1,6 +1,6 @@
 from ebooklib import epub
-from typing import List
-from src.models.data_models import ProcessedArticle
+from typing import List, Optional
+from src.models.data_models import ProcessedArticle, WeatherInfo
 
 
 def _build_a4_style() -> str:
@@ -18,6 +18,7 @@ def generate_epub(
     output_path: str,
     articles_per_page: int = 1,
     use_a4_css: bool = False,
+    weather_infos: Optional[List[WeatherInfo]] = None,
 ) -> str:
     """Generiert eine EPUB-Datei aus Artikeln.
 
@@ -26,6 +27,7 @@ def generate_epub(
         output_path: Zielpfad der EPUB-Datei.
         articles_per_page: Wie viele Artikel pro EPUB-Seite zusammengefasst werden.
         use_a4_css: Wenn True, wird ein einfaches A4-Stylesheet eingebunden.
+        weather_infos: Optionale Wettervorhersageeinträge, die als eigenes Kapitel eingefügt werden.
     """
     book = epub.EpubBook()
     book.set_identifier("newsletter")
@@ -43,6 +45,23 @@ def generate_epub(
             content=_build_a4_style(),
         )
         book.add_item(style_item)
+
+    if weather_infos:
+        weather_html_parts = []
+        for info in weather_infos:
+            snippet = info.forecast_snippet or ""
+            weather_html_parts.append(f"<p>{snippet}</p>")
+        weather_content = "".join(weather_html_parts)
+        c = epub.EpubHtml(
+            title="Wettervorhersage",
+            file_name="weather.xhtml",
+            lang="de",
+        )
+        c.content = weather_content
+        if style_item:
+            c.add_item(style_item)
+        book.add_item(c)
+        chapters.append(c)
 
     for start in range(0, len(articles), articles_per_page):
         batch = articles[start : start + articles_per_page]

--- a/test_epub_utils.py
+++ b/test_epub_utils.py
@@ -1,5 +1,5 @@
 from src.utils.epub_utils import generate_epub
-from src.models.data_models import ProcessedArticle
+from src.models.data_models import ProcessedArticle, WeatherInfo
 
 
 def test_generate_epub(tmp_path):
@@ -8,6 +8,7 @@ def test_generate_epub(tmp_path):
         ProcessedArticle(title="B", summary="Sum B"),
     ]
     out_file = tmp_path / "test.epub"
-    generate_epub(articles, str(out_file), articles_per_page=2, use_a4_css=True)
+    weather = [WeatherInfo(location="Zurich", temperature_celsius=20.0, condition="sonnig", forecast_snippet="Tag 1: 20°C sonnig")]
+    generate_epub(articles, str(out_file), articles_per_page=2, use_a4_css=True, weather_infos=weather)
     assert out_file.exists()
 

--- a/test_openweather.py
+++ b/test_openweather.py
@@ -1,0 +1,24 @@
+from unittest.mock import patch
+import os
+from src.agents.data_fetchers.openweathermap_fetcher import OpenWeatherMapFetcher
+from src.models.data_models import WeatherInfo
+
+sample_response = {
+    "list": [
+        {"dt_txt": "2025-06-01 12:00:00", "main": {"temp": 20, "humidity": 50}, "weather": [{"description": "sunny", "icon": "01d"}], "wind": {"speed": 5}},
+        {"dt_txt": "2025-06-02 12:00:00", "main": {"temp": 21, "humidity": 55}, "weather": [{"description": "cloudy", "icon": "02d"}], "wind": {"speed": 4}},
+        {"dt_txt": "2025-06-03 12:00:00", "main": {"temp": 22, "humidity": 60}, "weather": [{"description": "rain", "icon": "09d"}], "wind": {"speed": 3}},
+        {"dt_txt": "2025-06-04 12:00:00", "main": {"temp": 19, "humidity": 65}, "weather": [{"description": "sunny", "icon": "01d"}], "wind": {"speed": 2}},
+        {"dt_txt": "2025-06-05 12:00:00", "main": {"temp": 18, "humidity": 70}, "weather": [{"description": "rain", "icon": "09d"}], "wind": {"speed": 6}},
+    ]
+}
+
+@patch("requests.get")
+def test_fetch_weather(mock_get):
+    mock_get.return_value.json.return_value = sample_response
+    mock_get.return_value.raise_for_status.return_value = None
+    os.environ["OPENWEATHER_API_KEY"] = "dummy"
+    fetcher = OpenWeatherMapFetcher(city="Zurich", api_key_name="OPENWEATHER_API_KEY")
+    data = fetcher.fetch_data()
+    assert len(data) == 5
+    assert all(isinstance(d, WeatherInfo) for d in data)


### PR DESCRIPTION
## Summary
- implement `OpenWeatherMapFetcher` for 5‑day weather
- expose weather fetcher in orchestrator and pass data to EPUB generation
- extend `generate_epub` to include optional weather info
- add tests for new features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a7a3d1ac8320ae004aeabae34819