### PR TITLE
Add Europeana art fetch and description agent

### DIFF
--- a/src/agents/data_fetchers/__init__.py
+++ b/src/agents/data_fetchers/__init__.py
@@ -1,0 +1,4 @@
+from .newsapi_fetcher import NewsAPIFetcher
+from .europeana_fetcher import EuropeanaFetcher
+
+__all__ = ["NewsAPIFetcher", "EuropeanaFetcher"]

--- a/src/agents/data_fetchers/europeana_fetcher.py
+++ b/src/agents/data_fetchers/europeana_fetcher.py
@@ -1,0 +1,48 @@
+import logging
+from typing import List
+import requests
+
+from src.agents.data_fetchers.base_fetcher import BaseDataFetcher
+from src.models.data_models import Artwork
+from src.utils.config_loader import get_env_variable
+
+logger = logging.getLogger(__name__)
+
+class EuropeanaFetcher(BaseDataFetcher):
+    """Ruft Kunstwerke über die Europeana API ab."""
+
+    BASE_URL = "https://api.europeana.eu/record/v2/search.json"
+
+    def __init__(self, query: str, rows: int = 1, api_key_env: str = "EUROPEANA_API_KEY"):
+        super().__init__(source_name="Europeana")
+        self.query = query
+        self.rows = rows
+        self.api_key = get_env_variable(api_key_env, "apidemo")
+
+    def fetch_data(self) -> List[Artwork]:
+        params = {"wskey": self.api_key, "query": self.query, "rows": self.rows}
+        artworks: List[Artwork] = []
+        try:
+            resp = requests.get(self.BASE_URL, params=params, timeout=20)
+            resp.raise_for_status()
+            data = resp.json()
+            for item in data.get("items", []):
+                title = (item.get("title") or [None])[0]
+                artist = (item.get("dcCreator") or [None])[0]
+                preview = (item.get("edmPreview") or [None])[0]
+                location = (item.get("dataProvider") or [None])[0]
+                epoch = (item.get("year") or [None])[0]
+                artworks.append(
+                    Artwork(
+                        title=title or "Unbekannt",
+                        image_url=preview,
+                        artist=artist,
+                        location=location,
+                        epoch=str(epoch) if epoch else None,
+                        europeana_id=item.get("id"),
+                    )
+                )
+            logger.info(f"Europeana lieferte {len(artworks)} Ergebnisse für '{self.query}'.")
+        except Exception as e:
+            logger.error(f"Fehler beim Abrufen von Europeana-Daten: {e}", exc_info=True)
+        return artworks

--- a/src/agents/llm_processors/__init__.py
+++ b/src/agents/llm_processors/__init__.py
@@ -1,9 +1,11 @@
 from .summarizer_agent import SummarizerAgent
 from .categorizer_agent import CategorizerAgent
 from .article_writer_agent import ArticleWriterAgent
+from .art_description_agent import ArtDescriptionAgent
 
 __all__ = [
     "SummarizerAgent",
     "CategorizerAgent",
     "ArticleWriterAgent",
+    "ArtDescriptionAgent",
 ]

--- a/src/agents/llm_processors/art_description_agent.py
+++ b/src/agents/llm_processors/art_description_agent.py
@@ -1,0 +1,46 @@
+import logging
+from typing import List, Optional
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+
+from src.agents.llm_processors.base_processor import BaseLLMProcessor
+from src.models.data_models import Artwork
+
+logger = logging.getLogger(__name__)
+
+class ArtDescriptionAgent(BaseLLMProcessor):
+    """Erzeugt eine kurze Beschreibung eines Kunstwerks."""
+
+    def __init__(self, model_name: Optional[str] = None, temperature: float = 0.7):
+        super().__init__(model_name=model_name, temperature=temperature)
+        self.prompt = ChatPromptTemplate.from_messages([
+            (
+                "system",
+                "Du bist ein Kunstexperte und gibst prägnante Beschreibungen.",
+            ),
+            (
+                "human",
+                """
+Beschreibe das Kunstwerk in wenigen Sätzen. Erwähne den Künstler, den Ort, an dem es ausgestellt ist, und ordne es einer Kunstepoche zu.
+Titel: {title}
+Künstler: {artist}
+Ort: {location}
+Epoche: {epoch}
+""",
+            ),
+        ])
+        self.chain = self.prompt | self.llm | StrOutputParser()
+        logger.info(
+            f"ArtDescriptionAgent initialisiert mit Modell '{self.model_name}'."
+        )
+
+    def describe_artwork(self, art: Artwork) -> str:
+        return self.chain.invoke({
+            "title": art.title,
+            "artist": art.artist or "Unbekannt",
+            "location": art.location or "Unbekannt",
+            "epoch": art.epoch or "Unbekannt",
+        }).strip()
+
+    def process_batch(self, artworks: List[Artwork]) -> List[str]:
+        return [self.describe_artwork(a) for a in artworks]

--- a/src/europeana_demo.py
+++ b/src/europeana_demo.py
@@ -1,0 +1,39 @@
+"""Kleines Beispielskript zum Abrufen eines Kunstwerks von Europeana
+und zur Erstellung einer Kurzbeschreibung mittels LLM."""
+
+import logging
+import requests
+
+from src.utils.logging_setup import setup_logging
+from src.utils.config_loader import load_env
+from src.agents.data_fetchers.europeana_fetcher import EuropeanaFetcher
+from src.agents.llm_processors.art_description_agent import ArtDescriptionAgent
+
+
+def main() -> None:
+    load_env()
+    setup_logging()
+    logger = logging.getLogger(__name__)
+
+    fetcher = EuropeanaFetcher(query="Monet", rows=1)
+    artworks = fetcher.fetch_data()
+    if not artworks:
+        logger.error("Keine Kunstwerke gefunden.")
+        return
+
+    art = artworks[0]
+    logger.info(f"Gefundenes Kunstwerk: {art.title}")
+
+    if art.image_url:
+        resp = requests.get(art.image_url)
+        with open("tmp/europeana_preview.jpg", "wb") as f:
+            f.write(resp.content)
+        logger.info("Vorschaubild gespeichert unter tmp/europeana_preview.jpg")
+
+    agent = ArtDescriptionAgent()
+    description = agent.describe_artwork(art)
+    print("Beschreibung:\n" + description)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/models/data_models.py
+++ b/src/models/data_models.py
@@ -87,11 +87,22 @@ class Birthday(BaseModel):
 class WeatherInfo(BaseModel):
     location: str
     temperature_celsius: float
-    condition: str 
+    condition: str
     humidity_percent: Optional[float] = Field(default=None)
     wind_speed_kmh: Optional[float] = Field(default=None)
-    icon_url: Optional[HttpUrl] = Field(default=None) 
-    forecast_snippet: Optional[str] = Field(default=None) 
+    icon_url: Optional[HttpUrl] = Field(default=None)
+    forecast_snippet: Optional[str] = Field(default=None)
+
+class Artwork(BaseModel):
+    """Ein Kunstwerk, das aus Europeana abgefragt wurde."""
+
+    title: str
+    image_url: Optional[HttpUrl] = Field(default=None)
+    artist: Optional[str] = Field(default=None)
+    location: Optional[str] = Field(default=None)
+    epoch: Optional[str] = Field(default=None)
+    description: Optional[str] = Field(default=None)
+    europeana_id: Optional[str] = Field(default=None)
 
 class NewsletterSection(BaseModel):
     title: str 


### PR DESCRIPTION
## Summary
- model new `Artwork` structure
- add Europeana fetcher to retrieve artworks
- add art description LLM agent
- expose new agents in `__init__` files
- include a demo script fetching a Monet painting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a7b615f88320904ebd84a0368edf