### PR TITLE
Improve docs and logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Example configuration for local testing
+OPENAI_API_KEY=your-openai-key
+OPENWEATHER_API_KEY=your-weather-key
+NEWSAPI_API_KEY=your-newsapi-key
+LOG_LEVEL=INFO
+#LOG_FILE=logs/newsletter.log
+#LOG_ROTATE_SIZE_MB=5
+#LOG_ROTATE_BACKUP_COUNT=3

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# Newsletter Department
+
+This project contains a small pipeline that fetches news and other information and assembles a simple newsletter. The code is intentionally lightweight so that it can be executed locally without additional infrastructure.
+
+## Setup
+
+1. Create a Python virtual environment (optional but recommended).
+2. Install the dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Copy `.env.example` to `.env` and fill in the required API keys.
+
+## Running the pipeline
+
+Execute the entry point directly:
+
+```bash
+python main.py
+```
+
+Logging can be configured via the environment variables `LOG_LEVEL` and `LOG_FILE`.
+
+## Tests
+
+Tests are located in the `tests/` folder. After installing the requirements you can run them with:
+
+```bash
+pytest
+```
+
+## Environment variables
+
+The following variables are used by the code (all are optional for testing except API keys for the fetchers you want to use):
+
+- `OPENAI_API_KEY` – required for the LLM processors
+- `OPENAI_DEFAULT_MODEL` – model name, default `gpt-3.5-turbo`
+- `OPENWEATHER_API_KEY` – required for weather data
+- `NEWSAPI_API_KEY` – required for news articles
+- `NEWSLETTER_SOURCE_BLACKLIST` – comma separated list of sources to ignore
+- `NEWSLETTER_CATEGORIES` – list of categories for the newsletter
+- `NEWSLETTER_TOP_ARTICLE_COUNT` – number of articles that are fully written
+- `LOG_LEVEL` – logging level, e.g. `INFO`
+- `LOG_FILE` – path to a log file
+- `LOG_ROTATE_SIZE_MB` – if set to a number >0, rotating log files will be used
+- `LOG_ROTATE_BACKUP_COUNT` – number of rotated log files to keep (default 3)
+
+See `.env.example` for a minimal example.

--- a/src/utils/logging_setup.py
+++ b/src/utils/logging_setup.py
@@ -2,6 +2,7 @@
 # Konfiguriert das zentrale Logging für die Anwendung.
 
 import logging
+from logging.handlers import RotatingFileHandler
 import sys
 import os
 from typing import Optional
@@ -9,15 +10,23 @@ from typing import Optional
 # Basiskonfiguration, falls setup_logging nicht explizit aufgerufen wird oder früh geloggt wird
 logging.basicConfig(level=logging.WARNING, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
-def setup_logging(log_level_str: str = "INFO", log_file: Optional[str] = None):
+def setup_logging(
+    log_level_str: str = "INFO",
+    log_file: Optional[str] = None,
+    rotate_size_mb: int = 0,
+    backup_count: int = 3,
+):
     """
     Konfiguriert das Logging-System für die gesamte Anwendung.
     Diese Funktion sollte möglichst früh im Anwendungslauf aufgerufen werden (z.B. in main.py).
 
     Args:
         log_level_str (str): Logging-Level als String (z.B. "DEBUG", "INFO", "WARNING").
-        log_file (Optional[str]): Optionaler Pfad zu einer Log-Datei. 
-                                   Wenn None, wird nur auf der Konsole geloggt.
+        log_file (Optional[str]): Optionaler Pfad zu einer Log-Datei. Wenn None,
+            wird nur auf der Konsole geloggt.
+        rotate_size_mb (int): Wenn >0 wird ein RotatingFileHandler verwendet und
+            die Log-Datei bei dieser Größe (in MB) rotiert.
+        backup_count (int): Anzahl der zu behaltenden Log-Dateien bei Rotation.
     """
     # Hole den Root-Logger, um die Konfiguration global anzuwenden.
     root_logger = logging.getLogger()
@@ -65,16 +74,37 @@ def setup_logging(log_level_str: str = "INFO", log_file: Optional[str] = None):
     if effective_log_file:
         try:
             log_dir = os.path.dirname(effective_log_file)
-            if log_dir and not os.path.exists(log_dir): # Erstelle Verzeichnis, falls nicht vorhanden
+            if log_dir and not os.path.exists(log_dir):
                 os.makedirs(log_dir)
-            
-            file_handler = logging.FileHandler(effective_log_file, mode='a', encoding='utf-8') # 'a' für append
+
+            rotate_size_str = os.getenv("LOG_ROTATE_SIZE_MB", str(rotate_size_mb))
+            backup_count_str = os.getenv("LOG_ROTATE_BACKUP_COUNT", str(backup_count))
+            try:
+                max_bytes = int(rotate_size_str) * 1024 * 1024
+            except ValueError:
+                print(f"WARNUNG: Ungültiger Wert für LOG_ROTATE_SIZE_MB: '{rotate_size_str}'. Rotation deaktiviert.", file=sys.stderr)
+                max_bytes = 0
+            try:
+                backup_count_val = int(backup_count_str)
+            except ValueError:
+                print(f"WARNUNG: Ungültiger Wert für LOG_ROTATE_BACKUP_COUNT: '{backup_count_str}'. Nutze 3.", file=sys.stderr)
+                backup_count_val = 3
+
+            if max_bytes > 0:
+                file_handler = RotatingFileHandler(
+                    effective_log_file,
+                    maxBytes=max_bytes,
+                    backupCount=backup_count_val,
+                    encoding="utf-8",
+                )
+            else:
+                file_handler = logging.FileHandler(effective_log_file, mode="a", encoding="utf-8")
+
             file_handler.setFormatter(formatter)
-            file_handler.setLevel(numeric_level) # Setze Level auch für den Datei-Handler
+            file_handler.setLevel(numeric_level)
             root_logger.addHandler(file_handler)
             logging.info(f"Logging zusätzlich in Datei konfiguriert: {os.path.abspath(effective_log_file)}")
         except Exception as e:
-            # Nutze print, da Logging hier ggf. noch nicht voll initialisiert ist für Fehlermeldungen
             print(f"FEHLER: Konnte Datei-Log-Handler für '{effective_log_file}' nicht erstellen: {e}", file=sys.stderr)
     
     # Eine erste Log-Nachricht, um zu signalisieren, dass das Logging (neu) konfiguriert wurde.

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,20 @@
+import os
+import pytest
+
+from src.utils.config_loader import get_env_variable, get_api_key
+
+
+def test_get_env_variable_with_default(monkeypatch):
+    monkeypatch.delenv("SOME_VAR", raising=False)
+    assert get_env_variable("SOME_VAR", "default") == "default"
+
+
+def test_get_env_variable_missing_and_none(monkeypatch):
+    monkeypatch.delenv("SOME_VAR", raising=False)
+    assert get_env_variable("SOME_VAR") is None
+
+
+def test_get_api_key_raises(monkeypatch):
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    with pytest.raises(ValueError):
+        get_api_key("SECRET_KEY")


### PR DESCRIPTION
## Summary
- add README with setup and environment variable information
- provide sample `.env.example`
- add rotating log support in `setup_logging`
- unit tests for config loader helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842966262c88320a89291b2d0af6f3c